### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-tag.yaml
+++ b/.github/workflows/auto-tag.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main  # Replace with your default branch if different
 
+permissions:
+  contents: write
+
 jobs:
   auto-tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tcosolutions/aigraphcodescan/security/code-scanning/2](https://github.com/tcosolutions/aigraphcodescan/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's functionality:
- It needs `contents: write` to push tags to the repository.
- Other permissions, such as `contents: read`, are implicitly included in `contents: write`.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job (`auto-tag`) in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
