### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches:
       - main  # Replace with your default branch if different
-      
+
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/tcosolutions/aigraphcodescan/security/code-scanning/1](https://github.com/tcosolutions/aigraphcodescan/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow primarily involves reading repository contents and publishing a package to PyPI, the minimal permissions required are `contents: read`. This ensures that the `GITHUB_TOKEN` has only the necessary access to perform the tasks in the workflow.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. Alternatively, it can be added specifically to the `publish` job if other jobs are added later that require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
